### PR TITLE
fix emojiful loadCustomEmojis wrong can't mixin patchouli font

### DIFF
--- a/src/main/java/io/alwa/patchful/mixins/BookTextRendererMixin.java
+++ b/src/main/java/io/alwa/patchful/mixins/BookTextRendererMixin.java
@@ -15,6 +15,6 @@ public class BookTextRendererMixin {
 
     @Inject(method = "render(Lnet/minecraft/client/gui/GuiGraphics;IIF)V", at = @At(value = "INVOKE_ASSIGN", target = "Lvazkii/patchouli/common/book/Book;getFontStyle()Lnet/minecraft/network/chat/Style;"))
     void patchfulRender(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks, CallbackInfo ci, @Local Font font) {
-        font = ClientEmojiHandler.oldFontRenderer;
+        font = ClientEmojiHandler.oldFontRenderer == null ? font : ClientEmojiHandler.oldFontRenderer;
     }
 }

--- a/src/main/java/io/alwa/patchful/mixins/GuiBookMixin.java
+++ b/src/main/java/io/alwa/patchful/mixins/GuiBookMixin.java
@@ -20,7 +20,7 @@ public class GuiBookMixin {
     public void patchfulInit(Minecraft minecraft, int width, int height, CallbackInfo ci) {
         var screenClass = (Screen)(Object)this;
         if (screenClass instanceof GuiBook) {
-            this.font = ClientEmojiHandler.oldFontRenderer;
+            this.font = ClientEmojiHandler.oldFontRenderer == null ? font : ClientEmojiHandler.oldFontRenderer;
         }
     }
 }

--- a/src/main/java/io/alwa/patchful/mixins/TextLayouterMixin.java
+++ b/src/main/java/io/alwa/patchful/mixins/TextLayouterMixin.java
@@ -12,6 +12,6 @@ public class TextLayouterMixin {
 
     @ModifyVariable(method = "Lvazkii/patchouli/client/book/text/TextLayouter;layout(Lnet/minecraft/client/gui/Font;Ljava/util/List;)V", at = @At("HEAD"), ordinal = 0, argsOnly = true)
     private Font patchfulFont(Font font) {
-        return ClientEmojiHandler.oldFontRenderer;
+        return ClientEmojiHandler.oldFontRenderer == null ? font : ClientEmojiHandler.oldFontRenderer;
     }
 }


### PR DESCRIPTION
[Emojiful SourceCode](https://github.com/InnovativeOnlineIndustries/Emojiful/blob/1.21/Common/src/main/java/com/hrznstudio/emojiful/ClientEmojiHandler.java)

When Emojiful run loadCustomEmojis wrong, oldFontRenderer is Null. Add a check to prevent null pointer exceptions.